### PR TITLE
Upload check

### DIFF
--- a/Calliope App/Bluetooth/CalliopeBLEDevice.swift
+++ b/Calliope App/Bluetooth/CalliopeBLEDevice.swift
@@ -56,7 +56,7 @@ class CalliopeBLEDevice: NSObject, CBPeripheralDelegate {
             }
 		} else if state == .connected {
 			//immediately evaluate whether in playground mode
-            DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + BluetoothConstants.couplingDelay) {
+            updateQueue.asyncAfter(deadline: DispatchTime.now() + BluetoothConstants.couplingDelay) {
 				self.evaluateMode()
 			}
         } else if state == .evaluateMode {

--- a/Calliope App/Bluetooth/CalliopeTypes/FlashableCalliope.swift
+++ b/Calliope App/Bluetooth/CalliopeTypes/FlashableCalliope.swift
@@ -35,7 +35,9 @@ class FlashableCalliope: CalliopeBLEDevice {
             transferFirmware()
         } else if state == .usageReady && rebootingForPartialFlashing {
             rebootingForPartialFlashing = false
-            rebootForPartialFlashingDone()
+            updateQueue.async {
+                self.startPartialFlashing()
+            }
         }
     }
 
@@ -174,12 +176,12 @@ class FlashableCalliope: CalliopeBLEDevice {
         }
         
         if value[0] == .REGION && value[1] == .PROGRAM_REGION {
-            LogNotify.log("Program region: \(value[2..<6].hexEncodedString()) to \(value[6..<10].hexEncodedString()) - hash: \(value[10..<18].hexEncodedString())")
+            LogNotify.log("Program region: \(value[2..<6].hexEncodedString()) to \(value[6..<10].hexEncodedString()) - hash: \(value[10..<18].hexEncodedString()) - new hash: \(hexProgramHash.hexEncodedString())")
             receivedProgramHash()
             return
         }
 
-        if value[0] == .REGION && value[1] == 0 {
+        if value[0] == .REGION && value[1] == .EMBEDDED_REGION {
             LogNotify.log("Soft region: \(value[2..<6].hexEncodedString()) to \(value[6..<10].hexEncodedString()) - hash: \(value[10..<18].hexEncodedString())")
             receivedEmbedHash()
             return

--- a/Calliope App/de.lproj/Localizable.strings
+++ b/Calliope App/de.lproj/Localizable.strings
@@ -131,6 +131,9 @@
 "No" = "Nein";
 
 /* No comment provided by engineer. */
+"No changes to upload" = "Keine Änderungen zu übertragen";
+
+/* No comment provided by engineer. */
 "No description available" = "Keine Beschreibung verfügbar";
 
 /* No comment provided by engineer. */

--- a/Calliope App/en.lproj/Localizable.strings
+++ b/Calliope App/en.lproj/Localizable.strings
@@ -131,6 +131,9 @@
 "No" = "No";
 
 /* No comment provided by engineer. */
+"No changes to upload" = "No changes to upload";
+
+/* No comment provided by engineer. */
 "No description available" = "No description available";
 
 /* No comment provided by engineer. */


### PR DESCRIPTION
Änderungen um das Crashen der App zu verhindern wenn diese den Mini in den Flash-Modus neustartet und zusätzlich ein Check ob es Änderungen gibt die übertragen werden sollen bzw eine Meldung wenn nicht.

Und in Calliope App/Bluetooth/CalliopeBLEDevice.swift war an einer Stelle die 'DispatchQueue.main' hardcoded statt die Referenz 'updateQueue' zu selbiger zu verwenden.