### PR TITLE
Size Exceeded "fix" mit der Hilfe von @Tsisar.

### DIFF
--- a/Calliope App/Model/Hex.swift
+++ b/Calliope App/Model/Hex.swift
@@ -67,7 +67,7 @@ struct HexFile: Hex, Equatable {
             let parser = HexParser(url:url)
             var bin = Data()
             parser.parse { (address, data) in
-                if address >= 0x18000 && address < 0x40000 {
+                if address >= 0x18000 && address < 0x3C000 {
                     bin.append(data)
                 }
             }


### PR DESCRIPTION
0x18000 bis <0x3C000 ist offenbar der Bereich in dem der Programm Code für den Mini abgelegt werden soll.
Ab 0x3C000 enthält der Mini Daten, die angelehnt an die Dokumentation https://github.com/lancaster-university/codal-microbit-v2/blob/master/docs/MemoryMap.md für irgendetwas zuständig sind.
Das einzige was ich dazu rausfinden konnte, ist dass dieser Bereich offenbar nie beschrieben wird.
Selbst wenn ich ohne die Änderung in diesem Commit das Programm so groß gemacht habe, wie der Mini es noch mit einem Full-Flash angenommen hat, ist dieser Bereich nie erreicht worden, was nahelegt dass der Mini intern diesen Bereich zum schreiben meidet.

Die Änderung in diesem Commit trimmt denn Programm Code auf genau diese größe, was allerdings bedeutet dass bei MakeCode ein Teil fehlt, welche Aufgabe auch immer dieser Rest am Ende, der offenbar "optional" ist, hat.

Vielleicht sollte der Vorgang so angepasst werden dass eine Warnung gegeben wird dass das EoF des Codes außerhalb des nutzbaren Bereichs lag.
Zumindest bis irgendjemand rausfinden kann warum MakeCode so verdammt große Programme zurück gibt.