### PR TITLE
Automatisches Verbinden zum definierten Mini

### DIFF
--- a/Calliope App/Bluetooth/CalliopeBLEDevice.swift
+++ b/Calliope App/Bluetooth/CalliopeBLEDevice.swift
@@ -56,7 +56,7 @@ class CalliopeBLEDevice: NSObject, CBPeripheralDelegate {
             }
 		} else if state == .connected {
 			//immediately evaluate whether in playground mode
-            DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + BluetoothConstants.couplingDelay) {
+            updateQueue.asyncAfter(deadline: DispatchTime.now() + BluetoothConstants.couplingDelay) {
 				self.evaluateMode()
 			}
         } else if state == .evaluateMode {

--- a/Calliope App/Bluetooth/CalliopeBLEDevice.swift
+++ b/Calliope App/Bluetooth/CalliopeBLEDevice.swift
@@ -79,6 +79,7 @@ class CalliopeBLEDevice: NSObject, CBPeripheralDelegate {
 
 	let peripheral : CBPeripheral
 	let name : String
+    var autoConnect : Bool = true
 
 	lazy var servicesWithUndiscoveredCharacteristics: Set<CBUUID> = {
         return requiredServicesUUIDs.union(optionalServicesUUIDs)
@@ -99,6 +100,7 @@ class CalliopeBLEDevice: NSObject, CBPeripheralDelegate {
 	public func hasConnected() {
 		if state == .discovered {
 			state = .connected
+            autoConnect = true
 		}
 	}
 

--- a/Calliope App/Bluetooth/CalliopeBLEDiscovery.swift
+++ b/Calliope App/Bluetooth/CalliopeBLEDiscovery.swift
@@ -50,7 +50,9 @@ class CalliopeBLEDiscovery: NSObject, CBCentralManagerDelegate {
 				//manual timeout (system timeout is too long)
 				bluetoothQueue.asyncAfter(deadline: DispatchTime.now() + BluetoothConstants.connectTimeout) {
 					if self.connectedCalliope == nil {
-						self.centralManager.cancelPeripheralConnection(connectingCalliope.peripheral)
+                        LogNotify.log("disabling auto connect for \(connectingCalliope)")
+                        connectingCalliope.autoConnect = false
+                        self.centralManager.cancelPeripheralConnection(connectingCalliope.peripheral)
                         self.updateQueue.async { self.errorBlock( NSLocalizedString("Connection to calliope timed out!", comment: "") ) }
 					}
 				}
@@ -115,6 +117,9 @@ class CalliopeBLEDiscovery: NSObject, CBCentralManagerDelegate {
 	private func redetermineState() {
 		if connectedCalliope != nil {
 			state = .connected
+            for calliope in discoveredCalliopes {
+                calliope.value.autoConnect = true
+            }
 		} else if connectingCalliope != nil {
 			state = .connecting
 		} else if centralManager.isScanning {

--- a/Calliope App/Bluetooth/CalliopeTypes/FlashableCalliope.swift
+++ b/Calliope App/Bluetooth/CalliopeTypes/FlashableCalliope.swift
@@ -35,7 +35,9 @@ class FlashableCalliope: CalliopeBLEDevice {
             transferFirmware()
         } else if state == .usageReady && rebootingForPartialFlashing {
             rebootingForPartialFlashing = false
-            rebootForPartialFlashingDone()
+            updateQueue.async {
+                self.startPartialFlashing()
+            }
         }
     }
 
@@ -174,12 +176,12 @@ class FlashableCalliope: CalliopeBLEDevice {
         }
         
         if value[0] == .REGION && value[1] == .PROGRAM_REGION {
-            LogNotify.log("Program region: \(value[2..<6].hexEncodedString()) to \(value[6..<10].hexEncodedString()) - hash: \(value[10..<18].hexEncodedString())")
+            LogNotify.log("Program region: \(value[2..<6].hexEncodedString()) to \(value[6..<10].hexEncodedString()) - hash: \(value[10..<18].hexEncodedString()) - new hash: \(hexProgramHash.hexEncodedString())")
             receivedProgramHash()
             return
         }
 
-        if value[0] == .REGION && value[1] == 0 {
+        if value[0] == .REGION && value[1] == .EMBEDDED_REGION {
             LogNotify.log("Soft region: \(value[2..<6].hexEncodedString()) to \(value[6..<10].hexEncodedString()) - hash: \(value[10..<18].hexEncodedString())")
             receivedEmbedHash()
             return

--- a/Calliope App/Model/Settings.swift
+++ b/Calliope App/Model/Settings.swift
@@ -29,6 +29,10 @@ public enum SettingsKey: String, CaseIterable {
     case defaultHexFileURL = "calliopeDefaultHexFilePreference"
     case blinkingHeartURL = "calliopeBlinkingHeartHexPreference"
     
+    case autoDiscovery = "autoDiscoveryPreference"
+    case restoreLastMatrix = "restoreLastMatrixPreference" // key for IF to restore the matrix
+    case lastMatrix = "lastMatrix" // key for storing the matrix
+
     case resetSettings = "resetSettingsPreference"
 }
 
@@ -46,6 +50,9 @@ public struct Settings {
     static var defaultRobertaEnabled = true
     static var defaultPlaygroundsEnabled = UIDevice.current.userInterfaceIdiom != .phone
 
+    static var defaultAutoDiscoveryEnabled = true
+    static var defaultRestoreLastMatrixEnabled = true
+    
     static var defaultAppVersion = "1.0"
 
     static var defaultResetSettingsValue = false
@@ -81,6 +88,13 @@ public struct Settings {
             return defaultHexFileUrl
         case .blinkingHeartURL:
             return defaultBlinkingHeartUrl
+            
+        case .autoDiscovery:
+            return defaultAutoDiscoveryEnabled
+        case .restoreLastMatrix:
+            return defaultRestoreLastMatrixEnabled
+        case .lastMatrix:
+            return ""
 
         case .resetSettings:
             return false

--- a/Calliope App/Model/Settings.swift
+++ b/Calliope App/Model/Settings.swift
@@ -29,7 +29,6 @@ public enum SettingsKey: String, CaseIterable {
     case defaultHexFileURL = "calliopeDefaultHexFilePreference"
     case blinkingHeartURL = "calliopeBlinkingHeartHexPreference"
     
-    case autoDiscovery = "autoDiscoveryPreference"
     case restoreLastMatrix = "restoreLastMatrixPreference" // key for IF to restore the matrix
     case lastMatrix = "lastMatrix" // key for storing the matrix
 
@@ -50,7 +49,6 @@ public struct Settings {
     static var defaultRobertaEnabled = true
     static var defaultPlaygroundsEnabled = UIDevice.current.userInterfaceIdiom != .phone
 
-    static var defaultAutoDiscoveryEnabled = true
     static var defaultRestoreLastMatrixEnabled = true
     
     static var defaultAppVersion = "1.0"
@@ -89,8 +87,6 @@ public struct Settings {
         case .blinkingHeartURL:
             return defaultBlinkingHeartUrl
             
-        case .autoDiscovery:
-            return defaultAutoDiscoveryEnabled
         case .restoreLastMatrix:
             return defaultRestoreLastMatrixEnabled
         case .lastMatrix:

--- a/Calliope App/Settings.bundle/Root.plist
+++ b/Calliope App/Settings.bundle/Root.plist
@@ -8,22 +8,6 @@
 	<array>
 		<dict>
 			<key>Type</key>
-			<string>PSGroupSpecifier</string>
-			<key>Title</key>
-			<string>App Settings</string>
-		</dict>
-		<dict>
-			<key>Type</key>
-			<string>PSToggleSwitchSpecifier</string>
-			<key>Title</key>
-			<string>Automatic Discovery</string>
-			<key>Key</key>
-			<string>autoDiscoveryPreference</string>
-			<key>DefaultValue</key>
-			<true/>
-		</dict>
-		<dict>
-			<key>Type</key>
 			<string>PSToggleSwitchSpecifier</string>
 			<key>Title</key>
 			<string>Restore Last Matrix</string>

--- a/Calliope App/Settings.bundle/Root.plist
+++ b/Calliope App/Settings.bundle/Root.plist
@@ -10,6 +10,32 @@
 			<key>Type</key>
 			<string>PSGroupSpecifier</string>
 			<key>Title</key>
+			<string>App Settings</string>
+		</dict>
+		<dict>
+			<key>Type</key>
+			<string>PSToggleSwitchSpecifier</string>
+			<key>Title</key>
+			<string>Automatic Discovery</string>
+			<key>Key</key>
+			<string>autoDiscoveryPreference</string>
+			<key>DefaultValue</key>
+			<true/>
+		</dict>
+		<dict>
+			<key>Type</key>
+			<string>PSToggleSwitchSpecifier</string>
+			<key>Title</key>
+			<string>Restore Last Matrix</string>
+			<key>Key</key>
+			<string>restoreLastMatrixPreference</string>
+			<key>DefaultValue</key>
+			<true/>
+		</dict>
+		<dict>
+			<key>Type</key>
+			<string>PSGroupSpecifier</string>
+			<key>Title</key>
 			<string>Playgrounds</string>
 		</dict>
 		<dict>

--- a/Calliope App/Settings.bundle/de.lproj/Settings.strings
+++ b/Calliope App/Settings.bundle/de.lproj/Settings.strings
@@ -1,4 +1,10 @@
 /* (No Comment) */
+"Automatic Discovery" = "Automatische Suche";
+
+/* (No Comment) */
+"App Settings" = "App Einstellungen";
+
+/* (No Comment) */
 "App Version" = "App Version";
 
 /* (No Comment) */
@@ -21,6 +27,9 @@
 
 /* (No Comment) */
 "Playgrounds" = "Calliope mini Swift Playground";
+
+/* (No Comment) */
+"Restore Last Matrix" = "Letzte Matrix Laden";
 
 /* (No Comment) */
 "Reset Settings" = "Reset Einstellungen";

--- a/Calliope App/Settings.bundle/de.lproj/Settings.strings
+++ b/Calliope App/Settings.bundle/de.lproj/Settings.strings
@@ -1,10 +1,4 @@
 /* (No Comment) */
-"Automatic Discovery" = "Automatische Suche";
-
-/* (No Comment) */
-"App Settings" = "App Einstellungen";
-
-/* (No Comment) */
 "App Version" = "App Version";
 
 /* (No Comment) */

--- a/Calliope App/Settings.bundle/en.lproj/Settings.strings
+++ b/Calliope App/Settings.bundle/en.lproj/Settings.strings
@@ -1,10 +1,4 @@
 /* (No Comment) */
-"Automatic Discovery" = "Automatic Discovery";
-
-/* (No Comment) */
-"App Settings" = "App Settings";
-
-/* (No Comment) */
 "App Version" = "App Version";
 
 /* (No Comment) */

--- a/Calliope App/Settings.bundle/en.lproj/Settings.strings
+++ b/Calliope App/Settings.bundle/en.lproj/Settings.strings
@@ -1,4 +1,10 @@
 /* (No Comment) */
+"Automatic Discovery" = "Automatic Discovery";
+
+/* (No Comment) */
+"App Settings" = "App Settings";
+
+/* (No Comment) */
 "App Version" = "App Version";
 
 /* (No Comment) */
@@ -21,6 +27,9 @@
 
 /* (No Comment) */
 "Playgrounds" = "Calliope mini Swift Playground";
+
+/* (No Comment) */
+"Restore Last Matrix" = "Restore Last Matrix";
 
 /* (No Comment) */
 "Reset Settings" = "Reset Settings";

--- a/Calliope App/ViewsAndControllers/CollapsingConnectionView/ConnectionView/MatrixConnectionViewController.swift
+++ b/Calliope App/ViewsAndControllers/CollapsingConnectionView/ConnectionView/MatrixConnectionViewController.swift
@@ -177,6 +177,9 @@ class MatrixConnectionViewController: UIViewController, CollapsingViewController
 		case .discovering, .discovered:
 			if let calliope = self.calliopeWithCurrentMatrix {
 				evaluateCalliopeState(calliope)
+                if connectButton.connectionState == .readyToConnect {
+                    connect()
+                }
 			} else {
 				matrixView.isUserInteractionEnabled = true
 				connectButton.connectionState = .searching
@@ -185,6 +188,9 @@ class MatrixConnectionViewController: UIViewController, CollapsingViewController
 		case .discoveredAll:
 			if let matchingCalliope = calliopeWithCurrentMatrix {
 				evaluateCalliopeState(matchingCalliope)
+                if connectButton.connectionState == .readyToConnect && matchingCalliope.autoConnect {
+                    connect()
+                }
 			} else {
 				matrixView.isUserInteractionEnabled = true
 				connectButton.connectionState = .notFoundRetry

--- a/Calliope App/ViewsAndControllers/CollapsingConnectionView/ConnectionView/MatrixConnectionViewController.swift
+++ b/Calliope App/ViewsAndControllers/CollapsingConnectionView/ConnectionView/MatrixConnectionViewController.swift
@@ -238,7 +238,8 @@ class MatrixConnectionViewController: UIViewController, CollapsingViewController
         LogNotify.log("adding delayed discovery to queue")
         DispatchQueue.main.asyncAfter(deadline: .now() + .seconds(5)) {
             self.delayedDiscovery = false
-            if self.connector.state == .discoveredAll && self.connectButton.connectionState != .readyToPlay {
+            if !self.matrixView.isBlank() && (self.connector.state == .initialized ||
+                self.connector.state == .discoveredAll && self.connectButton.connectionState != .readyToPlay) {
                 self.connector.startCalliopeDiscovery()
             }
         }

--- a/Calliope App/ViewsAndControllers/CollapsingConnectionView/ConnectionView/MatrixConnectionViewController.swift
+++ b/Calliope App/ViewsAndControllers/CollapsingConnectionView/ConnectionView/MatrixConnectionViewController.swift
@@ -251,7 +251,7 @@ class MatrixConnectionViewController: UIViewController, CollapsingViewController
 		} else if calliope.state == .usageReady {
 			self.collapseButton.connectionState = .connected
             LogNotify.log("last pattern:\r\(matrixView.getMatrixString())")
-            UserDefaults.standard.set(matrixView.getMatrixString(), forKey: "lastMatrix")
+            UserDefaults.standard.set(matrixView.getMatrixString(), forKey: SettingsKey.lastMatrix.rawValue)
 		} else {
 			self.collapseButton.connectionState = .connecting
 		}

--- a/Calliope App/ViewsAndControllers/CollapsingConnectionView/ConnectionView/MatrixConnectionViewController.swift
+++ b/Calliope App/ViewsAndControllers/CollapsingConnectionView/ConnectionView/MatrixConnectionViewController.swift
@@ -231,16 +231,22 @@ class MatrixConnectionViewController: UIViewController, CollapsingViewController
 		}
 	}
     
-    private func startDelayedDiscovery() {
+    private func startDelayedDiscovery(delaySeconds:Int = 7) {
         if delayedDiscovery { return }
         delayedDiscovery = true
         
         LogNotify.log("adding delayed discovery to queue")
-        DispatchQueue.main.asyncAfter(deadline: .now() + .seconds(5)) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + .seconds(delaySeconds)) {
             self.delayedDiscovery = false
-            if !self.matrixView.isBlank() && (self.connector.state == .initialized ||
-                self.connector.state == .discoveredAll && self.connectButton.connectionState != .readyToPlay) {
-                self.connector.startCalliopeDiscovery()
+            if self.collapseButton.expansionState == .closed {
+                if !self.matrixView.isBlank() && (self.connector.state == .initialized ||
+                    self.connector.state == .discoveredAll && self.connectButton.connectionState != .readyToPlay) {
+                    self.connector.startCalliopeDiscovery()
+                }
+            }
+            else {
+                // the matrix view is open so don't start a discovery as the connection attempt prevents user input to it
+                self.startDelayedDiscovery(delaySeconds: 2)
             }
         }
     }

--- a/Calliope App/ViewsAndControllers/CollapsingConnectionView/ConnectionView/MatrixView.swift
+++ b/Calliope App/ViewsAndControllers/CollapsingConnectionView/ConnectionView/MatrixView.swift
@@ -57,6 +57,37 @@ final class MatrixView: UIView {
         }
         updateBlock()
     }
+    
+    func isBlank() -> Bool {
+        for b1 in matrix {
+            for b2 in b1 {
+                if b2 { return false }
+            }
+        }
+        return true
+    }
+    
+    func getMatrixString() -> String {
+        var result = ""
+        for b1 in matrix {
+            for b2 in b1 {
+                result += (b2 ? "1" : "0")
+            }
+        }
+        return result
+    }
+    
+    func setMatrixString(pattern:String) {
+        if pattern.count != getMatrixString().count { return }
+        
+        var index = 0
+        for (i1,b1) in matrix.enumerated() {
+            for (i2,_) in b1.enumerated() {
+                matrix[i1][i2] = (pattern[index] == "1") ? true : false
+                index += 1
+            }
+        }
+    }
 
     let sf = 0.03
 

--- a/Calliope App/ViewsAndControllers/EditorsAndPrograms/HexFileStoreDialog.swift
+++ b/Calliope App/ViewsAndControllers/EditorsAndPrograms/HexFileStoreDialog.swift
@@ -38,7 +38,7 @@ enum HexFileStoreDialog {
             notSaved(nil)
         })
 
-        alert.addAction(UIAlertAction(title: NSLocalizedString("OK", comment: ""), style: .default) { _ in
+        alert.addAction(UIAlertAction(title: NSLocalizedString("Save Program", comment: ""), style: .default) { _ in
             do {
                 let enteredName = alert.textFields?[0].text ?? name
                 //TODO clean up name

--- a/Calliope App/de.lproj/Localizable.strings
+++ b/Calliope App/de.lproj/Localizable.strings
@@ -131,6 +131,9 @@
 "No" = "Nein";
 
 /* No comment provided by engineer. */
+"No changes to upload" = "Keine Änderungen zu übertragen";
+
+/* No comment provided by engineer. */
 "No description available" = "Keine Beschreibung verfügbar";
 
 /* No comment provided by engineer. */

--- a/Calliope App/en.lproj/Localizable.strings
+++ b/Calliope App/en.lproj/Localizable.strings
@@ -131,6 +131,9 @@
 "No" = "No";
 
 /* No comment provided by engineer. */
+"No changes to upload" = "No changes to upload";
+
+/* No comment provided by engineer. */
 "No description available" = "No description available";
 
 /* No comment provided by engineer. */


### PR DESCRIPTION
Änderungen:
- Wenn ein Muster eingegeben und der entsprechende Mini gefunden wird, muss nicht mehr manuell auf den grünen Button geklickt werden um zu verbinden
- Bei Verlust der Verbindung zum Mini oder Eingabe eines Musters dass noch nicht gefunden wurde, wird alle 5 Sekunden erneut versucht zu diesem zu verbinden
- Das zuletzt verbundene Muster wird gespeichert und beim Neustart der App direkt in das Muster Panel geladen
- Ein Setting in den App Einstellungen kann dies ausschalten

Dieser Branch baut auf dem Upload Check Branch auf, daher zeigt er derzeit beim Vergleich mehr Änderungen an als tatsächlich enthalten.